### PR TITLE
Adds support for raw latitude and longitude address inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/map-component",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "description": "Map Component for Adalo",
   "main": "index.js",
   "scripts": {

--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -81,7 +81,7 @@ export default class Map extends Component {
     // load the addresses here instead of componentDidMount
     // because markerCollection is not immediately available
     if (markerCollection && !loaded && !editor) {
-      this.loadAddresses(prevPops)
+      this.loadAddresses()
     }
   }
 
@@ -136,14 +136,14 @@ export default class Map extends Component {
     }
   }
 
-  async loadAddresses(prevPops) {
+  async loadAddresses() {
     const {
       apiKey,
       markerType,
       markerCollection,
       markers: { markerAddress },
       editor,
-    } = prevPops
+    } = this.props
     const { loaded } = this.state
 
     if (!markerCollection || loaded || editor) {

--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { ActivityIndicator, View, Text, StyleSheet, Image } from 'react-native'
+import { ActivityIndicator, View, Text, StyleSheet } from 'react-native'
 import { getMap, addNativeEvent } from './map'
 import { markerWidth, markerHeight, geocodeURL } from './config'
 import axios from 'axios'
@@ -8,6 +8,10 @@ import roadmap from './assets/roadmap.jpg'
 import satellite from './assets/satellite.jpg'
 import terrain from './assets/terrain.jpg'
 import defaultMarker from './assets/marker.png'
+
+// Matches a comma-separated latitude/longitude coordinate pair: "47.1231231, 179.99999999"
+// https://stackoverflow.com/questions/3518504/regular-expression-for-matching-latitude-longitude-coordinates
+const COORD_REG_EX = /^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)$/
 
 const stylesStatus = StyleSheet.create({
   wrapper: {
@@ -70,6 +74,15 @@ export default class Map extends Component {
     }
   }
 
+  async componentDidUpdate(prevPops) {
+    const { markerCollection, editor } = prevPops
+    const { loaded } = this.state
+
+    if (markerCollection && !loaded && !editor) {
+      this.loadAddresses(prevPops)
+    }
+  }
+
   static getDerivedStateFromProps(props, state) {
     const { addresses, loaded } = state
     const { markerType, markerCollection } = props
@@ -121,44 +134,58 @@ export default class Map extends Component {
     }
   }
 
-  loadAddresses = async () => {
-    let { loaded } = this.state
-
-    let {
+  async loadAddresses(prevPops) {
+    const {
       apiKey,
       markerType,
       markerCollection,
       markers: { markerAddress },
-    } = this.props
+      editor,
+    } = prevPops
+    const { loaded } = this.state
 
-    let addr =
+    if (!markerCollection || loaded || editor) {
+      return
+    }
+
+    const locations =
       markerType === 'simple'
         ? markerAddress
           ? [markerAddress]
           : []
         : markerCollection
-        ? markerCollection.map((m) => m.markers_list.markerAddress)
+        ? markerCollection.map(m => m.markers_list.markerAddress)
         : []
+    
+    const coordinates = []
+    const addresses = []
 
-    if (!loaded) {
-      let result = await axios.post(geocodeURL, {
-        addresses: addr,
-        key: apiKey,
-      })
+    for (const location of locations) {
+      if (COORD_REG_EX.test(location)) {
+        const [lat, lng] = location.split(',')
 
-      this.setState({
-        addresses: result.data,
-      })
-
-      if (
-        markerType === 'simple' ||
-        (markerType !== 'simple' && markerCollection)
-      ) {
-        this.setState({
-          loaded: true,
+        // this matches the shape of the geocoded coordinates below
+        coordinates.push({
+          name: location,
+          location: {
+            lat: parseFloat(lat.trim(), 10),
+            lng: parseFloat(lng.trim(), 10),
+          }
         })
+      } else {
+        addresses.push(location)
       }
     }
+
+    const { data: geocodedCoordinates } = await axios.post(geocodeURL, {
+      addresses,
+      key: apiKey,
+    })
+
+    this.setState({
+      addresses: [...coordinates, ...geocodedCoordinates],
+      loaded: true,
+    })
   }
 
   getFilteredAddresses = () => {
@@ -233,8 +260,6 @@ export default class Map extends Component {
         </View>
       )
     }
-
-    this.loadAddresses()
 
     if (!mapConfigLoaded) {
       return <ActivityIndicator />

--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -78,6 +78,8 @@ export default class Map extends Component {
     const { markerCollection, editor } = prevPops
     const { loaded } = this.state
 
+    // load the addresses here instead of componentDidMount
+    // because markerCollection is not immediately available
     if (markerCollection && !loaded && !editor) {
       this.loadAddresses(prevPops)
     }

--- a/src/Map/map.js
+++ b/src/Map/map.js
@@ -60,14 +60,14 @@ export const getMap = ({
       }}
     >
       {filteredMarkers &&
-        filteredMarkers.map((marker, index) => (
+        filteredMarkers.map(marker => (
           <Marker
             coordinate={{
               latitude: marker && marker.lat,
               longitude: marker && marker.lng,
             }}
             style={{ alignItems: 'center', justifyContent: 'center' }}
-            key={`marker ${index}`}
+            key={`${marker.lat}-${marker.lng}`}
             onPress={marker.onPress}
           >
             <Image

--- a/src/Map/map.web.js
+++ b/src/Map/map.web.js
@@ -52,8 +52,8 @@ export const getMap = ({
       }}
     >
       {filteredMarkers &&
-        filteredMarkers.map((marker, index) => (
-          <View lat={marker.lat} lng={marker.lng} onClick={marker.onPress} key={`marker ${index}`}>
+        filteredMarkers.map(marker => (
+          <View lat={marker.lat} lng={marker.lng} onClick={marker.onPress} key={`${marker.lat}-${marker.lng}`}>
             <Image
               resizeMode="contain"
               source={marker.image}

--- a/src/Map/map.web.js
+++ b/src/Map/map.web.js
@@ -52,8 +52,8 @@ export const getMap = ({
       }}
     >
       {filteredMarkers &&
-        filteredMarkers.map((marker) => (
-          <View lat={marker.lat} lng={marker.lng} onClick={marker.onPress}>
+        filteredMarkers.map((marker, index) => (
+          <View lat={marker.lat} lng={marker.lng} onClick={marker.onPress} key={`marker ${index}`}>
             <Image
               resizeMode="contain"
               source={marker.image}


### PR DESCRIPTION
## Problem
The map component accepts street addresses and sends them to our [geocoder](https://github.com/AdaloHQ/geocoder) service, which makes a request to Google's geocode service through a [node client](https://github.com/googlemaps/google-maps-services-js), which comes back with latitude and longitude coordinates for each address. The geocode service does not accept coordinates as an input, which means the map component would not display any markers if makers were using latitude and longitude instead of street addresses for their location data.

## Solution
The map component will now differentiate between street addresses and coordinates; it will send the former to the geocoder  while the latter can bypass the geocoder entirely and be sent straight to the map. Typically a maker will only use one or the other format, but this also takes into account a mix of formats, recombining the two types of addresses before sending them to the map.

## Developer Notes
Since working with coordinates is a synchronous operation (because it bypasses the geocoder) and we set state inside the `render` hook, it resulted in an infinite render loop and crashed the component. To implement support for coordinates I extracted that functionality into the `componentDidUpdate` hook.