### PR TITLE
Adds support for raw latitude and longitude address inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/map-component",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Map Component for Adalo",
   "main": "index.js",
   "scripts": {

--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -178,11 +178,18 @@ export default class Map extends Component {
       }
     }
 
-    const { data: geocodedCoordinates } = await axios.post(geocodeURL, {
+    const { data: geocodedLocations } = await axios.post(geocodeURL, {
       addresses,
       key: apiKey,
     })
 
+    const geocodedCoordinates = geocodedLocations.map(location => ({
+      name: location.name,
+      location: location.address ? location.address.geometry.location : { lat: null, lng: null },
+    }))
+
+    // we need to preserve the original order of string addresses/coordinates
+    // because getFilteredAddresses relies on indexes
     for (const coordinate of coordinates) {
       const { name, location, index } = coordinate
 

--- a/src/Map/map.js
+++ b/src/Map/map.js
@@ -1,7 +1,5 @@
 import MapView, { Marker, PROVIDER_GOOGLE } from 'react-native-maps'
 import {
-  View,
-  Text,
   Image,
   NativeModules,
   Platform,
@@ -18,7 +16,6 @@ export const addNativeEvent = (apiKey) => {
 }
 
 export const getMap = ({
-  apiKey,
   zoom,
   options,
   styles,
@@ -60,14 +57,14 @@ export const getMap = ({
       }}
     >
       {filteredMarkers &&
-        filteredMarkers.map((marker, index) => (
+        filteredMarkers.map(marker => (
           <Marker
             coordinate={{
               latitude: marker && marker.lat,
               longitude: marker && marker.lng,
             }}
             style={{ alignItems: 'center', justifyContent: 'center' }}
-            key={`marker ${index}`}
+            key={`${marker.lat}-${marker.lng}`}
             onPress={marker.onPress}
           >
             <Image

--- a/src/Map/map.web.js
+++ b/src/Map/map.web.js
@@ -1,7 +1,6 @@
 import GoogleMapReact from 'google-map-react'
-import { View, Text, Image, StyleSheet } from 'react-native'
+import { View, Image, StyleSheet } from 'react-native'
 import { markerWidth, markerHeight } from './config'
-import defaultMarker from './assets/marker.png'
 
 const additionalStyles = StyleSheet.create({
   markerImage: {
@@ -20,7 +19,6 @@ export const getMap = ({
   zoom,
   options,
   styles,
-  currentLocation,
   filteredMarkers,
 }) => {
   const defaultCenter = {
@@ -52,8 +50,8 @@ export const getMap = ({
       }}
     >
       {filteredMarkers &&
-        filteredMarkers.map((marker) => (
-          <View lat={marker.lat} lng={marker.lng} onClick={marker.onPress}>
+        filteredMarkers.map(marker => (
+          <View lat={marker.lat} lng={marker.lng} onClick={marker.onPress} key={`${marker.lat}-${marker.lng}`}>
             <Image
               resizeMode="contain"
               source={marker.image}


### PR DESCRIPTION
## Problem
The map component accepts street addresses and sends them to our [geocoder](https://github.com/AdaloHQ/geocoder) service, which makes a request to Google's geocode service through a [node client](https://github.com/googlemaps/google-maps-services-js), which comes back with latitude and longitude coordinates for each address. The geocode service does not accept coordinates as an input, which means the map component would not display any markers if makers were using latitude and longitude instead of street addresses for their location data.

## Solution
The map component will now differentiate between street addresses and coordinates; it will send the former to the geocoder  while the latter can bypass the geocoder entirely and be sent straight to the map. Typically a maker will only use one or the other format, but this also takes into account a mix of formats, recombining the two types of addresses before sending them to the map. The order is preserved; in fact, it has to be, because `getFilteredAddresses` uses indexes for some of its logic.

## Developer Notes
Since working with coordinates is a synchronous operation (because it bypasses the geocoder) and we set state inside the `render` hook, it resulted in an infinite render loop and crashed the component. To implement support for coordinates I extracted that functionality into the `componentDidUpdate` hook.