### PR TITLE
Render the map before data has loaded

### DIFF
--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -75,28 +75,30 @@ export default class Map extends Component {
     }
   }
 
-  async componentDidUpdate() {
-    const { markerType, markerCollection, editor, markers: { markerAddress } } = this.props
-    const { isLoaded, addresses, isLoading } = this.state
+  componentDidUpdate() {
+    const { editor } = this.props
+    const { isLoaded, isLoading } = this.state
 
     if (editor || isLoading) {
       return
     }
-    
-    // check for new data after the map has loaded
-    if (isLoaded) {
-      const shouldUnload =
-        (markerType === 'simple' && markerAddress && !addresses.length) ||
-        (markerType === 'multiple' && markerCollection && markerCollection.length !== addresses.length)
 
-      // unloads the map if the data it has (addresses) does not contain the data
-      // it receives (markerAddress for single or markerCollection for multiple)
-      if (shouldUnload) {
-        this.setState({ isLoaded: false })
-      }
+    if (isLoaded && this.mapShouldReload()) {
+      this.setState({ isLoaded: false })
     } else {
       this.loadAddresses()
     }
+  }
+
+  mapShouldReload() {
+    const { markerType, markerCollection, markers: { markerAddress } } = this.props
+    const { addresses } = this.state
+
+    if (markerType === 'simple') {
+      return addresses.length ? markerAddress !== addresses[0].name : markerAddress
+    }
+
+    return markerCollection && markerCollection.length !== addresses.length
   }
 
   fetchMapConfiguration() {


### PR DESCRIPTION
Regression from https://github.com/AdaloHQ/map-component/pull/33

## Problem
If you do not set an address (for a Single Marker) or a collection (for Multiple Markers) the map will not render in the preview/app. This is because the `loadAddresses` method is only triggered once there is a `markerAddress` (for a Single Marker) or a `markerCollection` (for Multiple Markers). The `loadAddresses` method sets the `isLoaded` state to `true`, which triggers the map render.

## Solution
Call `loadAddresses` if `isLoaded` is `false` (do not check for data). This will render the map 1) on-mount and 2) when `isLoaded` is reset to `false`. When data comes in (or is updated), check it against `addresses` according to the following logic:
- Single Markers: if there is a `markerAddress` but it doesn't match what is in `addresses` (or if there _isn't_ a `markerAddress` but there _are_ `addresses`), then reload.
- Multiple Markers: if there is a `markerCollection` and it's length is different from `addresses`, then reload.

The map does not "live reload" with new data. It's important to flip the `isLoaded` flag to `false` with new data so that the map can be completely unmounted from the DOM, and then re-mounted with fresh data.

The `getDerivedStateFromProps` hook was removed because it was unneeded; the logic can go into `componentDidUpdate`.