### PR TITLE
Fix loading condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/map-component",
-  "version": "0.5.2",
+  "version": "0.5.4",
   "description": "Map Component for Adalo",
   "main": "index.js",
   "scripts": {

--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -85,7 +85,9 @@ export default class Map extends Component {
 
     if (isLoaded && this.mapShouldReload()) {
       this.setState({ isLoaded: false })
-    } else {
+    }
+    
+    if (!isLoaded) {
       this.loadAddresses()
     }
   }

--- a/src/Map/map.js
+++ b/src/Map/map.js
@@ -57,14 +57,14 @@ export const getMap = ({
       }}
     >
       {filteredMarkers &&
-        filteredMarkers.map(marker => (
+        filteredMarkers.map((marker, index) => (
           <Marker
             coordinate={{
               latitude: marker && marker.lat,
               longitude: marker && marker.lng,
             }}
             style={{ alignItems: 'center', justifyContent: 'center' }}
-            key={`${marker.lat}-${marker.lng}`}
+            key={`${index}-${marker.lat}-${marker.lng}`}
             onPress={marker.onPress}
           >
             <Image

--- a/src/Map/map.web.js
+++ b/src/Map/map.web.js
@@ -37,7 +37,7 @@ export const getMap = ({
       defaultCenter={viewCenter}
       defaultZoom={zoom}
       options={options}
-      onGoogleApiLoaded={({ map, maps }) => {
+      onGoogleApiLoaded={({ map }) => {
         if (filteredMarkers.length > 1) {
           const bounds = new google.maps.LatLngBounds()
           for (let i = 0; i < filteredMarkers.length; i++) {
@@ -50,8 +50,8 @@ export const getMap = ({
       }}
     >
       {filteredMarkers &&
-        filteredMarkers.map(marker => (
-          <View lat={marker.lat} lng={marker.lng} onClick={marker.onPress} key={`${marker.lat}-${marker.lng}`}>
+        filteredMarkers.map((marker, index) => (
+          <View lat={marker.lat} lng={marker.lng} onClick={marker.onPress} key={`${index}-${marker.lat}-${marker.lng}`}>
             <Image
               resizeMode="contain"
               source={marker.image}


### PR DESCRIPTION
A poorly-written conditional led to infinite renders. We should only load addresses if they haven't been loaded in already, not if `mapShouldReload` evaluates to `false` as well 😓 .

I also added `index` as part of the keys for markers to prevent a bunch of console errors.