### PR TITLE
Clean up and refactor the map component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/map-component",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Map Component for Adalo",
   "main": "index.js",
   "scripts": {

--- a/src/Map/MapWrapper.js
+++ b/src/Map/MapWrapper.js
@@ -1,39 +1,22 @@
 import MapView, { Marker, PROVIDER_GOOGLE } from 'react-native-maps'
-import {
-  Image,
-  NativeModules,
-  Platform,
-  Dimensions,
-} from 'react-native'
+import { Image, Dimensions } from 'react-native'
+import { defaultZoom } from './config'
+
 const { height, width } = Dimensions.get('window')
 
-export const addNativeEvent = (apiKey) => {
-  if (Platform.OS === 'ios') {
-    var KeyModule = NativeModules.KeyModule
-    KeyModule.addEvent(apiKey)
-  } else {
-  }
-}
-
-export const getMap = ({
-  zoom,
+const MapWrapper = ({
   options,
   styles,
   currentLocation,
   filteredMarkers = [],
+  viewCenter,
 }) => {
   const mapType =
     options.mapTypeId === 'roadmap' ? 'standard' : options.mapTypeId
-  const defaultCenter = {
-    lat: 40.7831,
-    lng: -73.9712,
-  }
-  const LATITUDE_DELTA = Math.exp(Math.log(360) - (zoom + 1) * Math.LN2)
+
+  const LATITUDE_DELTA = Math.exp(Math.log(360) - (defaultZoom + 1) * Math.LN2)
   const LONGITUDE_DELTA = LATITUDE_DELTA * (width / height)
-  const viewCenter =
-    filteredMarkers.length > 0 && filteredMarkers[0]
-      ? { lat: filteredMarkers[0].lat, lng: filteredMarkers[0].lng }
-      : defaultCenter
+
   let mapRef = null
 
   return (
@@ -77,3 +60,5 @@ export const getMap = ({
     </MapView>
   )
 }
+
+export default MapWrapper

--- a/src/Map/MapWrapper.web.js
+++ b/src/Map/MapWrapper.web.js
@@ -1,6 +1,6 @@
 import GoogleMapReact from 'google-map-react'
 import { View, Image, StyleSheet } from 'react-native'
-import { markerWidth, markerHeight } from './config'
+import { markerWidth, markerHeight, defaultZoom } from './config'
 
 const additionalStyles = StyleSheet.create({
   markerImage: {
@@ -10,41 +10,29 @@ const additionalStyles = StyleSheet.create({
   },
 })
 
-export const addNativeEvent = (apiKey) => {
-  // Do nothing in case of web
-}
-
-export const getMap = ({
+const MapWrapper = ({
   apiKey,
-  zoom,
   options,
   styles,
-  filteredMarkers,
+  filteredMarkers = [],
+  viewCenter,
 }) => {
-  const defaultCenter = {
-    lat: 40.7831,
-    lng: -73.9712,
-  }
-
-  const viewCenter =
-    filteredMarkers.length > 0 && filteredMarkers[0]
-      ? { lat: filteredMarkers[0].lat, lng: filteredMarkers[0].lng }
-      : defaultCenter
-
   return (
     <GoogleMapReact
       bootstrapURLKeys={{ key: apiKey }}
       defaultCenter={viewCenter}
-      defaultZoom={zoom}
+      defaultZoom={defaultZoom}
       options={options}
       onGoogleApiLoaded={({ map }) => {
         if (filteredMarkers.length > 1) {
           const bounds = new google.maps.LatLngBounds()
-          for (let i = 0; i < filteredMarkers.length; i++) {
-            const marker = filteredMarkers[i]
-            const newPoint = new google.maps.LatLng(marker.lat, marker.lng)
+
+          for (const marker of filteredMarkers) {
+            const { lat, lng } = marker
+            const newPoint = new google.maps.LatLng(lat, lng)
             bounds.extend(newPoint)
           }
+
           map.fitBounds(bounds)
         }
       }}
@@ -62,3 +50,5 @@ export const getMap = ({
     </GoogleMapReact>
   )
 }
+
+export default MapWrapper

--- a/src/Map/config.js
+++ b/src/Map/config.js
@@ -1,3 +1,4 @@
 export const markerWidth = 25
 export const markerHeight = 41
 export const geocodeURL = "https://adalo-geocoder.herokuapp.com/"
+export const defaultZoom = 13

--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -128,8 +128,6 @@ export default class Map extends Component {
       markerCollection,
       markers: { markerAddress },
     } = this.props
-      console.log('LOAD ADDRESSES')
-
       // prevents unnecessary state updates in didComponentUpdate
       this.setState({
         isLoading: true
@@ -201,10 +199,9 @@ export default class Map extends Component {
       markers: { markerSource, markerImage, onPress },
     } = this.props
 
-    const isSimple = markerType === 'simple'
     let filteredMarkers = []
 
-    if (isSimple) {
+    if (markerType === 'simple') {
       filteredMarkers.push({
         lat: addresses.length > 0 ? addresses[0].location.lat : null,
         lng: addresses.length > 0 ? addresses[0].location.lng : null,
@@ -240,8 +237,14 @@ export default class Map extends Component {
   }
 
   render() {
-    const { apiKey, editor, style: { mapStyle, customStyle, currentLocation } } = this.props
+    const {
+      apiKey,
+      editor,
+      style: { mapStyle, customStyle, currentLocation }
+    } = this.props
+
     const { errorMessage, isLoaded } = this.state
+
     const filteredMarkers = this.getFilteredAddresses()
 
     if (editor) {

--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
-import { ActivityIndicator, View, Text, StyleSheet } from 'react-native'
-import { getMap, addNativeEvent } from './map'
+import { ActivityIndicator, View, Text, StyleSheet, Platform } from 'react-native'
+import MapWrapper from './MapWrapper'
 import { markerWidth, markerHeight, geocodeURL } from './config'
 import axios from 'axios'
 import hybrid from './assets/hybrid.jpg'
@@ -49,37 +49,48 @@ const placeholderImages = {
   terrain,
 }
 
+const defaultCenter = {
+  lat: 40.7831,
+  lng: -73.9712,
+}
+
+const StatusMessage = ({ message }) => (
+  <View style={stylesStatus.wrapper}>
+    <Text style={stylesStatus.text}>{message}</Text>
+  </View>
+)
 export default class Map extends Component {
   state = {
-    apiKey: null,
-    markerAddress: null,
     addresses: [],
-    markerImage: null,
-    onPress: null,
-    mapStyle: null,
-    customStyle: null,
-    currentLocation: false,
     errorMessage: null,
-    zoom: 13,
-    markerType: null,
-    mapConfigLoaded: false,
     isLoaded: false,
     isLoading: false,
   }
 
   componentDidMount() {
-    const { editor } = this.props
+    const { editor, apiKey } = this.props
 
-    if (!editor) {
-      this.fetchMapConfiguration() 
+    if (editor) {
+      return
+    }
+
+    if (!apiKey) {
+      return this.setState({
+        errorMessage: 'API Key is not set.....',
+      })
+    }
+
+    if (Platform.OS === 'ios') {
+      const KeyModule = NativeModules.KeyModule
+      KeyModule.addEvent(apiKey)
     }
   }
 
   componentDidUpdate() {
-    const { editor } = this.props
+    const { editor, apiKey } = this.props
     const { isLoaded, isLoading } = this.state
 
-    if (editor || isLoading) {
+    if (editor || isLoading || !apiKey) {
       return
     }
 
@@ -103,36 +114,6 @@ export default class Map extends Component {
     return markerCollection && markerCollection.length !== addresses.length
   }
 
-  fetchMapConfiguration() {
-    const {
-      apiKey,
-      markerType,
-      markers: { markerAddress, onPress },
-      style: { mapStyle, customStyle, currentLocation },
-    } = this.props
-
-    if (!apiKey) {
-      return this.setState({
-        errorMessage: 'API Key is not set.....',
-        mapConfigLoaded: true,
-      })
-    }
-
-    addNativeEvent(apiKey)
-
-    this.setState({
-      apiKey,
-      markerType,
-      markerAddress,
-      onPress,
-      mapStyle,
-      customStyle,
-      currentLocation,
-      errorMessage: null,
-      mapConfigLoaded: true,
-    })
-  }
-
   getMapOptions(maps) {
     return {
       fullscreenControl: false,
@@ -147,6 +128,8 @@ export default class Map extends Component {
       markerCollection,
       markers: { markerAddress },
     } = this.props
+      console.log('LOAD ADDRESSES')
+
       // prevents unnecessary state updates in didComponentUpdate
       this.setState({
         isLoading: true
@@ -257,39 +240,26 @@ export default class Map extends Component {
   }
 
   render() {
-    let { apiKey, editor } = this.props
-
-    let {
-      mapStyle,
-      customStyle,
-      currentLocation,
-      errorMessage,
-      mapConfigLoaded,
-      isLoaded,
-    } = this.state
-
+    const { apiKey, editor, style: { mapStyle, customStyle, currentLocation } } = this.props
+    const { errorMessage, isLoaded } = this.state
     const filteredMarkers = this.getFilteredAddresses()
 
     if (editor) {
       return (
         <View style={{ width: '100%', height: '100%' }}>
           <img
-            src={placeholderImages[this.props.style.mapStyle]}
+            src={placeholderImages[mapStyle]}
             style={{ objectFit: 'cover', width: 'auto', height: '100%' }}
           />
         </View>
       )
     }
 
-    if (!mapConfigLoaded) {
-      return <ActivityIndicator />
-    }
-
     if (errorMessage) {
       return <StatusMessage message={errorMessage} />
     }
 
-    let options = {
+    const options = {
       fullscreenControl: false,
       mapTypeId: mapStyle,
     }
@@ -301,29 +271,23 @@ export default class Map extends Component {
       catch (e) {}
     }
 
+    const viewCenter =
+      filteredMarkers.length
+        ? { lat: filteredMarkers[0].lat, lng: filteredMarkers[0].lng }
+        : defaultCenter
+
     return (
       <View style={{ width: '100%', height: '100%' }}>
-        {isLoaded &&
-          getMap({
-            apiKey,
-            zoom: this.state.zoom,
-            options,
-            styles,
-            currentLocation,
-            filteredMarkers,
-          })}
-      </View>
-    )
-  }
-}
-
-export class StatusMessage extends Component {
-  render() {
-    let { message } = this.props
-
-    return (
-      <View style={stylesStatus.wrapper}>
-        <Text style={stylesStatus.text}>{message}</Text>
+        {isLoaded ? (
+          <MapWrapper
+            apiKey={apiKey}
+            options={options}
+            styles={styles}
+            currentLocation={currentLocation}
+            filteredMarkers={filteredMarkers}
+            viewCenter={viewCenter}
+          />
+        ) : <ActivityIndicator />}
       </View>
     )
   }


### PR DESCRIPTION
## Problem
The map component is difficult to work with because it contains a fair bit of messy and dead code.

## Solution
This PR cleans up and refactors the map component:

- Converts the `getMap` function into a functional component; minimal changes required here, except renaming the export and the file to something that made sense (`MapWrapper`).
- Calculation for the initial `viewCenter` is identical in both the web and native files, so this was moved up to `map.js` and passed as props to both.
- The `defaultCenter` constant was only used by `viewCenter` ☝️ , so this was also moved up to `map.js`
- The exported `addNativeEvent` function defined in the native js file was imported by `map.js` and called on `componentDidMount`. Since web does not need the functionality defined by the function, an empty `addNativeEvent` had to be defined in the web file. I deleted this function entirely and put the functionality inside `componentDidMount` wrapped in a check for the platform OS.
- I converted the `StatusMessage` component into a functional component.

I removed a lot of unneeded state variables from `map.js`:
- **apiKey**: accessed from `props`
- **markerAddress**: accessed from `props`
- **markerImage**: accessed from `props`
- **onPress**: accessed from `props`
- **mapStyle**: accessed from `props`
- **customStyle**: accessed from `props`
- **currentLocation**: accessed from `props`
- **markerType**: accessed from `props`
- **zoom**: is static, converted to a constant and imported by web and native files
- **mapConfigLoaded**: this is `false` by default and is flipped to `true` on-mount (if not in the editor). The only thing this controlled was the loading state, which means the loading state never really shows up because `mapConfigLoaded` is always true on first render. I removed this state entirely and render the loading state is `isLoading` is true.

This is not the be-all and end-all, there are still lots of things we could do (converting the top level component to be functional, adding a test suite, adding linters), but I had to draw the line somewhere, and this is enough for me to knock out device location for the web pretty quickly.