### PR TITLE
Fix: ensure map zooms to fit multiple markers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/map-component",
-  "version": "0.5.30",
+  "version": "0.5.31",
   "description": "Map Component for Adalo",
   "main": "index.js",
   "scripts": {

--- a/src/Map/MapWrapper.js
+++ b/src/Map/MapWrapper.js
@@ -33,6 +33,11 @@ const MapWrapper = ({
       mapType={mapType}
       customMapStyle={options.styles || []}
       ref={(map) => (mapRef = map)}
+      onMapReady={() => {
+        if (filteredMarkers.length > 1) {
+          mapRef.fitToElements(true)
+        }
+      }}
     >
       {filteredMarkers &&
         filteredMarkers.map(marker => (


### PR DESCRIPTION
During the React Native upgrades we removed functionality that zoomed the map to fit multiple markers.  This PR re-instates that functionality.

Published to Adalo Component Testing organization for testing under version 0.5.31