### PR TITLE
Feat: upgrade react-native-maps dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/map-component",
-  "version": "0.5.32",
+  "version": "0.5.33",
   "description": "Map Component for Adalo",
   "main": "index.js",
   "scripts": {
@@ -24,6 +24,6 @@
   "dependencies": {
     "axios": "^0.19.1",
     "google-map-react": "^1.1.5",
-    "react-native-maps": "^0.26.1"
+    "react-native-maps": "1.10.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/map-component",
-  "version": "0.5.33",
+  "version": "0.5.34",
   "description": "Map Component for Adalo",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/map-component",
-  "version": "0.5.34",
+  "version": "0.5.35",
   "description": "Map Component for Adalo",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/map-component",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "description": "Map Component for Adalo",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/map-component",
-  "version": "0.5.35",
+  "version": "0.5.36",
   "description": "Map Component for Adalo",
   "main": "index.js",
   "scripts": {

--- a/scripts/install_android.sh
+++ b/scripts/install_android.sh
@@ -2,20 +2,10 @@
 set -e
 set -x
 
-yarn add react-native-maps@0.26.1
-
 dir=$(dirname "${0}")
 key=$("${dir}/get_maps_api_key.js")
 
 cd android
-
-# ./build.gradle
-
-sed -i.bak '/targetSdkVersion/a\
-    supportLibVersion = "29.0.0"\
-    playServicesVersion = "17.0.0"\
-    androidMapsUtilsVersion = "0.6.2"\
-' ./build.gradle
 
 # AndroidManifest.xml
 

--- a/scripts/install_ios.sh
+++ b/scripts/install_ios.sh
@@ -2,10 +2,10 @@
 set -e
 set -x
 
-project_path=$(pwd)
-name=$PROJECT_NAME
-
+dir=$(dirname "${0}")
 key=$("${dir}/get_maps_api_key.js")
+
+name=$PROJECT_NAME
 
 cd ios
 

--- a/scripts/install_ios.sh
+++ b/scripts/install_ios.sh
@@ -12,6 +12,16 @@ cd ios
 # Replace `platform :ios, min_ios_version_supported`` with `platform :ios, '13.4'`
 sed -i.bak "s/platform :ios, min_ios_version_supported/platform :ios, '13.4'/g" Podfile
 
+# Add `rn_maps_path = '../node_modules/react-native-maps'` above `config = use_native_modules!`
+sed -i.bak '/config = use_native_modules!/i\
+rn_maps_path = '"'"'../node_modules/react-native-maps'"'"'\
+' Podfile
+
+# Add `pod 'react-native-google-maps', :path => rn_maps_path` above `config = use_native_modules!`
+sed -i.bak '/config = use_native_modules!/i\
+pod '"'"'react-native-google-maps'"'"', :path => rn_maps_path\
+' Podfile
+
 # Add `#import <GoogleMaps/GoogleMaps.h>` BEFORE `// MARKER_REACT_NATIVE_IOS_APP_DELEGATE_IMPORTS`
 sed -i.bak '/\/\/ MARKER_REACT_NATIVE_IOS_APP_DELEGATE_IMPORTS/i\
 #import <GoogleMaps/GoogleMaps.h>\

--- a/scripts/install_ios.sh
+++ b/scripts/install_ios.sh
@@ -5,165 +5,24 @@ set -x
 project_path=$(pwd)
 name=$PROJECT_NAME
 
-# Dependencies manually added for now
+key=$("${dir}/get_maps_api_key.js")
 
-yarn add react-native-maps@0.26.1
-
-# Podfile
 cd ios
 
-sed -i.bak '/use_native_modules/a\
-  pod "react-native-maps", path: "../node_modules/react-native-maps"\
-  pod "react-native-google-maps", path: "../node_modules/react-native-maps"  # Uncomment this line if you want to support GoogleMaps on iOS\
-  pod "GoogleMaps"  # Uncomment this line if you want to support GoogleMaps on iOS\
-  pod "Google-Maps-iOS-Utils" # Uncomment this line if you want to support GoogleMaps on iOS\
-' Podfile
+# Replace `platform :ios, min_ios_version_supported`` with `platform :ios, '13.4'`
+sed -i.bak "s/platform :ios, min_ios_version_supported/platform :ios, '13.4'/g" Podfile
 
-if grep -q post_install Podfile; then
-  echo "post_install already exists in Podfile"
+# Add `#import <GoogleMaps/GoogleMaps.h>` BEFORE `// MARKER_REACT_NATIVE_IOS_APP_DELEGATE_IMPORTS`
+sed -i.bak '/\/\/ MARKER_REACT_NATIVE_IOS_APP_DELEGATE_IMPORTS/i\
+#import <GoogleMaps/GoogleMaps.h>\
+' ./${name}/AppDelegate.mm
 
-  # add it after __apply_Xcode_12_5_M1_post_install_workaround(installer)
-  sed -i.bak '/__apply_Xcode_12_5_M1_post_install_workaround(installer)/a\
-  \
-  installer.pods_project.targets.each do |target|\
-    if target.name == "react-native-google-maps"\
-      target.build_configurations.each do |config|\
-        config.build_settings["CLANG_ENABLE_MODULES"] = "No"\
-      end\
-    end\
-    if target.name == "Google-Maps-iOS-Utils"\
-      target.build_configurations.each do |config|\
-        config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] = "12.4"\
-      end\
-    end\
-    if target.name == "React"\
-      target.remove_from_project\
-    end\
-  end\
-  ' Podfile
+# Add `[GMSServices provideAPIKey:@"GEO_API_KEY"];` AFTER `self.initialProps = @{};`
+sed -i.bak '/self.initialProps = @{};/a\
+  [GMSServices provideAPIKey:@"GEO_API_KEY"];\
+' ./${name}/AppDelegate.mm
 
-else
-  echo "post_install does not exist in Podfile"
-
-cat <<EOF >> Podfile
-post_install do |installer|
-  installer.pods_project.targets.each do |target|
-    if target.name == 'react-native-google-maps'
-      target.build_configurations.each do |config|
-        config.build_settings['CLANG_ENABLE_MODULES'] = 'No'
-      end
-    end
-    if target.name == 'Google-Maps-iOS-Utils'
-      target.build_configurations.each do |config|
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '8.0'
-      end
-    end
-    if target.name == "React"
-      target.remove_from_project
-    end
-  end
-end
-EOF
-fi
-
-# Enabling Google Maps on iOS
-
-{ 
-  # OLD REACT NATIVE
-  sed -i.bak '/UserNotifications.h/a\
-  #import <GoogleMaps/GoogleMaps.h>\
-  #import <React/RCTLog.h>\
-  \
-  @implementation KeyModule\
-  \
-  RCT_EXPORT_MODULE();\
-  \
-  RCT_EXPORT_METHOD(addEvent:(NSString *)apiKey)\
-  {\
-    [[NSNotificationCenter defaultCenter]postNotificationName:@"APIKeyNotification"\
-                                                      object:apiKey];\
-  }\
-  \
-  @end\
-  ' ./${name}/AppDelegate.m
-
-} || {
-  # NEW REACT NATIVE
-  sed -i.bak '/\/\/ MARKER_REACT_NATIVE_IOS_APP_DELEGATE_IMPORTS/i\
-  #import <GoogleMaps/GoogleMaps.h>\
-  #import <React/RCTLog.h>\
-  \
-  @implementation KeyModule\
-  \
-  RCT_EXPORT_MODULE();\
-  \
-  RCT_EXPORT_METHOD(addEvent:(NSString *)apiKey)\
-  {\
-    [[NSNotificationCenter defaultCenter]postNotificationName:@"APIKeyNotification"\
-                                                      object:apiKey];\
-  }\
-  \
-  @end\
-  ' ./${name}/AppDelegate.mm
-
-
-}
-
-{
-  # OLD REACT NATIVE
-  sed -i.bak '/didFinishLaunchingWithOptions/i\
-  - (void) receiveNotification:(NSNotification *) notification\
-    {\
-      if ([[notification name] isEqualToString:@"APIKeyNotification"]) {\
-        NSString *apiKey = notification.object;\
-        NSLog(@"Here is Google map API Key - %@", apiKey);\
-        [GMSServices provideAPIKey:apiKey];\
-      }\
-    }\
-  ' ./${name}/AppDelegate.m
-
-} || {
-  # NEW REACT NATIVE
-  sed -i.bak '/\/\/ MARKER_REACT_NATIVE_IOS_APP_DELEGATE_START/i\
-  - (void) receiveNotification:(NSNotification *) notification\
-    {\
-      if ([[notification name] isEqualToString:@"APIKeyNotification"]) {\
-        NSString *apiKey = notification.object;\
-        NSLog(@"Here is Google map API Key - %@", apiKey);\
-        [GMSServices provideAPIKey:apiKey];\
-      }\
-    }\
-  ' ./${name}/AppDelegate.mm
-}
-
-{
-  # OLD REACT NATIVE
-  sed -i.bak '/initWithDelegate/i\
-    [[NSNotificationCenter defaultCenter] addObserver:self\
-                                            selector:@selector(receiveNotification:)\
-                                                name:@"APIKeyNotification"\
-                                              object:nil];\
-  ' ./${name}/AppDelegate.m
-
-} || {
-  # NEW REACT NATIVE  
-  sed -i.bak '/\/\/ MARKER_REACT_NATIVE_IOS_APP_DELEGATE_DID_FINISH_LAUNCHING_WITH_OPTIONS/i\
-    [[NSNotificationCenter defaultCenter] addObserver:self\
-                                            selector:@selector(receiveNotification:)\
-                                                name:@"APIKeyNotification"\
-                                              object:nil];\
-  ' ./${name}/AppDelegate.mm
-
-}
-
-sed -i.bak '/@end/a\
-\
-#import <React/RCTBridgeModule.h>\
-\
-@interface KeyModule : NSObject <RCTBridgeModule>\
-@end\
-' ./${name}/AppDelegate.h
-
-cd ..
+# Replace `GEO_API_KEY` with the value of `key`
+sed -i.bak "s/GEO_API_KEY/${key}/g" ./${name}/AppDelegate.mm
 
 echo "react-native-maps configuration completed for iOS."

--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { ActivityIndicator, View, Text, StyleSheet, Platform, NativeModules } from 'react-native'
+import { ActivityIndicator, View, Text, StyleSheet, Platform } from 'react-native'
 import MapWrapper from './MapWrapper'
 import { markerWidth, markerHeight, geocodeURL } from './config'
 import axios from 'axios'
@@ -78,11 +78,6 @@ export default class Map extends Component {
       return this.setState({
         errorMessage: 'API Key is not set.....',
       })
-    }
-
-    if (Platform.OS === 'ios') {
-      const KeyModule = NativeModules.KeyModule
-      KeyModule.addEvent(apiKey)
     }
 
     if (Platform.OS === 'web' && currentLocation) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1084,6 +1084,11 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
 
+"@types/geojson@^7946.0.13":
+  version "7946.0.14"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.14.tgz#319b63ad6df705ee2a65a73ef042c8271e696613"
+  integrity sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==
+
 "@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
@@ -4779,10 +4784,12 @@ react-is@^16.8.1:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
 
-react-native-maps@^0.26.1:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-0.26.1.tgz#6ec316259b38d259c8974448d894bd7a23101da4"
-  integrity sha512-p4VTB8YB5ZmOmDRCUpoHZkm05amZwhIo04AJMBbB9+JAR2PNNfpo0vceoWX0Mag4wnePkdzPomeWMplr/wimTg==
+react-native-maps@1.10.3:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-1.10.3.tgz#a669ee3a8baa01d30c5c7af7bdc498428d0e8284"
+  integrity sha512-P8/Viq5vgW9FRhvfDFQHxq02cZUcDJu6VbBZar7c/voGDbD5nrTIA0qlpiUAmrs1ikd8+7S4QjXQlorppBBMvA==
+  dependencies:
+    "@types/geojson" "^7946.0.13"
 
 react-native-web@^0.9.5:
   version "0.9.5"


### PR DESCRIPTION
## Problem

We need to update our Map Component to be ready for the map rendering updates from Google

## Solution

The new version of Map Component is ready for testing in the Adalo Component Testing organisation as version `0.5.37`

- bump react-native-maps dependency from `0.26.1` to `1.10.3`
- simplify install scripts for both Android and iOS
- simplify `componentDidMount()` for iOS, removing the old way the component acquired its API Key
