### PR TITLE
Fix: web - map marker flicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "axios": "^0.19.1",
-    "google-maps-react-markers": "^2.0.10",
+    "google-maps-react-markers": "2.0.10",
     "react-native-maps": "1.10.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/map-component",
-  "version": "0.5.41",
+  "version": "0.5.42",
   "description": "Map Component for Adalo",
   "main": "index.js",
   "scripts": {
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "axios": "^0.19.1",
-    "google-map-react": "^1.1.5",
+    "google-maps-react-markers": "^2.0.10",
     "react-native-maps": "1.10.3"
   }
 }

--- a/src/Map/MapWrapper.web.js
+++ b/src/Map/MapWrapper.web.js
@@ -34,16 +34,20 @@ const MapWrapper = ({
     ))
   }, [filteredMarkers])
 
+  const mapOptions = useMemo(() => {
+    return {
+      ...options,
+      mapTypeControl: false,
+      streetViewControl: false,
+    }
+  }, [options])
+
   return (
     <GoogleMapReact
       apiKey={apiKey}
       defaultCenter={viewCenter}
       defaultZoom={defaultZoom}
-      options={{
-        ...options,
-        mapTypeControl: false,
-        streetViewControl: false,
-      }}
+      options={mapOptions}
       onGoogleApiLoaded={({ map }) => {
         if (filteredMarkers.length > 1) {
           const bounds = new google.maps.LatLngBounds()

--- a/src/Map/MapWrapper.web.js
+++ b/src/Map/MapWrapper.web.js
@@ -37,8 +37,12 @@ const MapWrapper = ({
   const mapOptions = useMemo(() => {
     return {
       ...options,
+      // disable the ability to switch map type (e.g. map, satellite, hybrid etc.)
       mapTypeControl: false,
+      // disable the ability to switch into Street View
       streetViewControl: false,
+      // disables the ability to click on various landmarks, shops etc. that Google Maps shows
+      clickableIcons: false,
     }
   }, [options])
 

--- a/src/Map/MapWrapper.web.js
+++ b/src/Map/MapWrapper.web.js
@@ -1,5 +1,6 @@
-import GoogleMapReact from 'google-map-react'
+import { useMemo } from 'react'
 import { View, Image, StyleSheet } from 'react-native'
+import GoogleMapReact from 'google-maps-react-markers'
 import { markerWidth, markerHeight, defaultZoom } from './config'
 
 const additionalStyles = StyleSheet.create({
@@ -17,12 +18,32 @@ const MapWrapper = ({
   filteredMarkers = [],
   viewCenter,
 }) => {
+  const markers = useMemo(() => {
+    if (!filteredMarkers) {
+      return []
+    }
+
+    return filteredMarkers.map(marker => (
+      <View lat={marker.lat} lng={marker.lng} onClick={marker.onPress} key={marker.key}>
+        <Image
+          resizeMode="contain"
+          source={marker.image}
+          style={[styles.markerImage, additionalStyles.markerImage]}
+        />
+      </View>
+    ))
+  }, [filteredMarkers])
+
   return (
     <GoogleMapReact
-      bootstrapURLKeys={{ key: apiKey }}
+      apiKey={apiKey}
       defaultCenter={viewCenter}
       defaultZoom={defaultZoom}
-      options={options}
+      options={{
+        ...options,
+        mapTypeControl: false,
+        streetViewControl: false,
+      }}
       onGoogleApiLoaded={({ map }) => {
         if (filteredMarkers.length > 1) {
           const bounds = new google.maps.LatLngBounds()
@@ -37,16 +58,7 @@ const MapWrapper = ({
         }
       }}
     >
-      {filteredMarkers &&
-        filteredMarkers.map(marker => (
-          <View lat={marker.lat} lng={marker.lng} onClick={marker.onPress} key={marker.key}>
-            <Image
-              resizeMode="contain"
-              source={marker.image}
-              style={[styles.markerImage, additionalStyles.markerImage]}
-            />
-          </View>
-        ))}
+      {markers}
     </GoogleMapReact>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1071,10 +1071,6 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@mapbox/point-geometry@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
-
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -2652,10 +2648,6 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
-eventemitter3@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
-
 eventemitter3@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
@@ -3104,14 +3096,10 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-google-map-react@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/google-map-react/-/google-map-react-1.1.5.tgz#ad88caa88085c6292dbb1f890c70ff75fbee3d47"
-  dependencies:
-    "@mapbox/point-geometry" "^0.1.0"
-    eventemitter3 "^1.1.0"
-    prop-types "^15.5.6"
-    scriptjs "^2.5.7"
+google-maps-react-markers@^2.0.10:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/google-maps-react-markers/-/google-maps-react-markers-2.0.10.tgz#dfebc99182c2aa2b9375b70110c0de6fc569d0b9"
+  integrity sha512-VEhiGeP2Oob1rh2FSPSkgFPNy6kW9TXbtG+igkj7nxpS0LRr9AZNFbHI5+Kapwok5e8WtqyWiqaN8LK+TkEHBA==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
@@ -3823,7 +3811,7 @@ loglevel@^1.6.8:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.8.tgz#8a25fb75d092230ecd4457270d80b54e28011171"
   integrity sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
@@ -4612,14 +4600,6 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.6:
-  version "15.7.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
-  dependencies:
-    loose-envify "^1.4.0"
-    object-assign "^4.1.1"
-    react-is "^16.8.1"
-
 prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
@@ -4779,10 +4759,6 @@ react-dom@^16.6.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.10.0"
-
-react-is@^16.8.1:
-  version "16.12.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
 
 react-native-maps@1.10.3:
   version "1.10.3"
@@ -5137,10 +5113,6 @@ schema-utils@^2.6.5, schema-utils@^2.6.6, schema-utils@^2.7.0:
     "@types/json-schema" "^7.0.4"
     ajv "^6.12.2"
     ajv-keywords "^3.4.1"
-
-scriptjs@^2.5.7:
-  version "2.5.9"
-  resolved "https://registry.yarnpkg.com/scriptjs/-/scriptjs-2.5.9.tgz#343915cd2ec2ed9bfdde2b9875cd28f59394b35f"
 
 select-hose@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3096,7 +3096,7 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-google-maps-react-markers@^2.0.10:
+google-maps-react-markers@2.0.10:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/google-maps-react-markers/-/google-maps-react-markers-2.0.10.tgz#dfebc99182c2aa2b9375b70110c0de6fc569d0b9"
   integrity sha512-VEhiGeP2Oob1rh2FSPSkgFPNy6kW9TXbtG+igkj7nxpS0LRr9AZNFbHI5+Kapwok5e8WtqyWiqaN8LK+TkEHBA==


### PR DESCRIPTION
NOTE: this PR is based off https://github.com/AdaloHQ/map-component/pull/60 which is currently in testing

## Problem

On the web version of this component, map markers flicker when you drag to move the map.

## Solution

It turns out this has been an issue with the `google-map-react` dependency for quite some time, related to React 18, and it's yet to be fixed!

Reference: https://github.com/google-map-react/google-map-react/issues/1143

Thankfully someone created a new version of the library - `google-maps-react-markers` - that supports React 18 properly.
The changes to the implementation of the library were minimal and it appears that all features and styling options available in the component manifest are correctly supported.