### PR TITLE
Fix: Map | 2 different API keys for map causing crashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/map-component",
-  "version": "0.5.44",
+  "version": "0.5.45",
   "description": "Map Component for Adalo",
   "main": "index.js",
   "scripts": {

--- a/scripts/installAndroid.ts
+++ b/scripts/installAndroid.ts
@@ -15,16 +15,22 @@ await backupFile(manifestFilePath)
 const metaTag = `    <meta-data android:name="com.google.android.geo.API_KEY" android:value="GEO_API_KEY" />`
 let manifestContent = await Deno.readTextFile(manifestFilePath)
 
-// insert meta-data tag before the closing </application> tag
-manifestContent = insertLineAfterString(
-  manifestContent,
-  '</application',
-  metaTag,
-  { insertBefore: true }
-)
+// check if there's already a meta-data tag with the API key
+if (manifestContent.includes('com.google.android.geo.API_KEY')) {
+  console.log(`AndroidManifest.xml already contains a meta-data tag with the API key`)
+} else {
+  // insert meta-data tag before the closing </application> tag
+  manifestContent = insertLineAfterString(
+    manifestContent,
+    '</application',
+    metaTag,
+    { insertBefore: true }
+  )
 
-// replace KEY with the actual key
-manifestContent = manifestContent.replaceAll('GEO_API_KEY', apiKey)
+  // replace KEY with the actual key
+  manifestContent = manifestContent.replaceAll('GEO_API_KEY', apiKey)
 
-await Deno.writeTextFile(manifestFilePath, manifestContent)
-console.log(`Finished updating AndroidManifest.xml`)
+  await Deno.writeTextFile(manifestFilePath, manifestContent)
+  console.log(`Finished updating AndroidManifest.xml`)
+}
+


### PR DESCRIPTION
A maker had an issue where they were using multiple components relying on `com.google.android.geo.API_KEY` in the Android manifest, where duplicate entries were created.  The caused the app build to fail.

Rather than have the component developer patch on their side, we can patch on ours to only add the `com.google.android.geo.API_KEY` metadata to the Android manifest if it isn't already present.